### PR TITLE
Fixing date = null issue

### DIFF
--- a/Fields/MultidatesPicker.php
+++ b/Fields/MultidatesPicker.php
@@ -59,10 +59,10 @@ if ( !class_exists('\Cmb2MultidatesPicker\Fields\MultidatesPicker') ) {
 					};
 					var pickerParams = <?php echo $multidatesParamsJs; ?>;
 					jQuery.extend(params, pickerParams);
-					<?php if ( is_array($escaped_value) && count($escaped_value > 0) ) { ?>
+					if ( document.getElementById('<?php echo $field->args['id']; ?>').value !== '' ) {
 						var dates = <?php echo $datesJs; ?>;
-						params.addDates=dates;
-					<?php } ?>
+						params.addDates = dates;
+					}
 					jQuery('#<?php echo $fieldName; ?>').multiDatesPicker(params);
 				</script>
 			<?php


### PR DESCRIPTION
Normal code always returns true and MultiDatesPicker doesn't function if you add blank 'date' variable. Since the field is hard-coded for the altField save parameter, you need to check the contents of this div for the value.